### PR TITLE
Fix crash typing in extension popup

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -65,6 +65,9 @@ sed -i '/private void showPopupOnAnchor() {/,/private void closePopup() {/ s|if 
 sed -i 's|buttonView.setIsPressed(true);|if (buttonView != null) buttonView.setIsPressed(true);|' chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListMediator.java
 sed -i '/[[:space:]]mWindowAndroid,/!b;n;s|[[:space:]]buttonView,|buttonView != null ? buttonView : mRecyclerViewDelegate.getContainerView(),|' chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListMediator.java # set popup anchor
 
+# ext: popup keyboard
+sed -i 's|private boolean handleKeyboardEvent(WebContents webContents, KeyEvent event) {|private boolean handleKeyboardEvent(WebContents webContents, KeyEvent event) { if (event == null) return false;|' chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionPopupContents.java
+
 # ext: pin
 sed -i '/Pref.PIN_EXTENSIONS_MENU_BUTTON, this::updateMenuButtonPinState);$/a\if (!mPrefService.getBoolean(Pref.PIN_EXTENSIONS_MENU_BUTTON)) { mContainer.findViewById(R.id.extensions_menu_button).setVisibility(View.GONE); }' chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsToolbarCoordinatorImpl.java
 sed -i '/"ExtensionsToolbarCoordinatorImpl.requestLayoutWithViewUtils()");$/a\if (!isMenuButtonPinned()) { mContainer.findViewById(R.id.extensions_menu_button).setVisibility(View.GONE); }' chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsToolbarCoordinatorImpl.java


### PR DESCRIPTION
### 1. Why this change?
Browser crashes when typing in an extension popup (e.g. Bitwarden). The
KeyEvent delivered by the IME is null, and handleKeyboardEvent
dereferences it directly, causing an NPE.

### 2. Steps to reproduce
1. Install the Bitwarden extension
2. Open its popup
3. Type in the input field inside the popup (triggers IME) → crash

### 3. What changed?
Added `if (event == null) return false;` at the start of
ExtensionActionPopupContents.handleKeyboardEvent to bail out early
when the event is null.