### PR TITLE
fix: cold-start splash hang with extension NTP overrides (iTab / #157)

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -93,6 +93,14 @@ sed -i 's|while (!(locale_path = locales.Next()).empty()) {|&if (locale_path.IsC
 sed -i 's|while (!(locale_folder = locales.Next()).empty()) {|&if (locale_folder.IsContentUri()) { locale_folder = locale_path.Append(locales.GetInfo().GetName()); }|' extensions/common/extension_l10n_util.cc
 sed -i '/extension_l10n_util::ValidateExtensionLocales($/,/error) &&$/{s|extension_l10n_util::ValidateExtensionLocales(|(extension_path_.IsVirtualDocumentPath() \|\| &|;s|error) &&|error)) \&\&|}' extensions/browser/unpacked_installer.cc
 
+# ext: ntp
+if version_lt "$VERSION" "152.0.7969.0"; then
+sed -i 's|import org.chromium.chrome.browser.url_constants.UrlConstantResolverFactory;|&\nimport org.chromium.chrome.browser.url_constants.UrlOverrideUtils;|' chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+sed -i 's|if (isTabNtp \&\& !currentTab.isNativePage()) {|if (isTabNtp \&\& !currentTab.isNativePage() \&\& !UrlOverrideUtils.isNtpOverrideEnabled() \&\& !UrlOverrideUtils.isWebUiNtpOverrideEnabled()) {|' chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+else
+sed -i 's|if (isTabNtp \&\& !currentTab.isNativePage() \&\& !isTabWebUiNtp) {|if (isTabNtp \&\& !currentTab.isNativePage() \&\& !isTabWebUiNtp \&\& !UrlOverrideUtils.isNtpOverrideEnabled()) {|' chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+fi
+
 # desktop: omnibox
 sed -i 's/is_desktop_android = !!BUILDFLAG(IS_DESKTOP_ANDROID);/is_desktop_android = false;/' components/omnibox/browser/zero_suggest_verbatim_match_provider.cc
 sed -i 's/is_android_mobile = is_android_any \&\& !is_android_desktop;/is_android_mobile = is_android_any \&\& is_android_desktop;/' components/omnibox/browser/autocomplete_result.cc


### PR DESCRIPTION
## Summary

Fixes cold start getting stuck on the Android splash/startup screen after installing extensions that override the new tab page (e.g. **iTab**, [New Tab Redirect](https://chromewebstore.google.com/detail/new-tab-redirect/icpgjfneehieebagbmdbhnlpiopdcmna)).

This addresses [#157](https://github.com/jqssun/android-titanium-browser/issues/157) and related NTP-override failures (also relevant to [#81](https://github.com/jqssun/android-titanium-browser/issues/81)).

### Root cause

With `is_desktop_android = true`, `ChromeNativeUrlOverriding` is on. When an extension sets `chrome_url_overrides.newtab`:

1. Java records NTP override in SharedPreferences.
2. Cold start / restore treats the active tab as an NTP that is **not** a `NativePage`.
3. `ChromeTabbedActivity.initializeState` waits for `Tab.onContentChanged` before calling `AppLaunchDrawBlocker.onActiveTabAvailable()`.
4. Extension NTPs never become a native page, so the pre-draw blocker may never clear → permanent splash.

Upstream already skips this wait for **WebUI NTP** (with an explicit comment that waiting can hang the rendering path). This change extends the same exemption to **extension** NTP overrides via `UrlOverrideUtils.isNtpOverrideEnabled()`.

### Approach

Keep `ChromeNativeUrlOverriding` enabled so `chrome_url_overrides.newtab` still works. Only skip the `AppLaunchDrawBlocker` wait when an extension NTP override is active—same pattern as WebUI NTP.

> **Note for reviewers:** This change was **vibe-coded** (AI-assisted). Please review the `patch.sh` sed carefully against current Chromium `ChromeTabbedActivity.initializeState` strings, and validate on device with an NTP-override extension before merge.

## Test plan

- [ ] Clean install / update build with this patch
- [ ] Install an NTP override extension (iTab or New Tab Redirect)
- [ ] Force-stop the browser, then cold-start from launcher
- [ ] Confirm splash dismisses and UI becomes usable
- [ ] Confirm new tab still loads the extension NTP (override still works)
- [ ] Confirm normal browsing (no extension NTP) still cold-starts cleanly
- [ ] Optional: long-press app icon → “New tab” with no background instance ([#157](https://github.com/jqssun/android-titanium-browser/issues/157) repro)

Closes #157